### PR TITLE
Fix JWT payload for auth middleware

### DIFF
--- a/node_backend/src/utils/token.ts
+++ b/node_backend/src/utils/token.ts
@@ -15,7 +15,11 @@ const JWT_EXPIRATION: jwt.SignOptions["expiresIn"] = process.env.JWT_EXPIRATION
   : "1h";
 
 export function generateToken(userId: number, role: string) {
-  return jwt.sign({ id: userId, role }, JWT_SECRET, {
+  // Use `userId` consistently across the codebase so that the auth middleware
+  // can correctly decode the JWT payload. Previously the token payload used an
+  // `id` property which caused `verifyToken` to fail because it expects a
+  // `userId` field.
+  return jwt.sign({ userId, role }, JWT_SECRET, {
     expiresIn: JWT_EXPIRATION,
   });
 }


### PR DESCRIPTION
## Summary
- fix token utility to use `userId` in JWT payload

## Testing
- `npm test --prefix node_backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686744bf695083288342d71a35edfae2

## Summary by Sourcery

Bug Fixes:
- Update token generation to use `userId` in the JWT payload instead of `id` to align with the auth middleware’s expected field